### PR TITLE
Fix mongo connection

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
       - MONGO_HOST=mongodb://mongo/resque
     ports:
       - "3000:3000"
+    networks:
+      - net
 
 networks:
   net:

--- a/server-start.js
+++ b/server-start.js
@@ -1,8 +1,8 @@
 process.env.NODE_ENV= process.env.NODE_ENV || 'development'
 process.env.SERVER_PORT= process.env.SERVER_PORT || '4040'
 process.env.JWT_SECRET='0a6b944d-d2fb-46fc-a85e-0295c986cd9f'
-process.env.MONGO_HOST='mongodb://localhost/new-mean'
-process.env.MONGO_PORT='27017'
+process.env.MONGO_HOST= process.env.MONGO_HOST || 'mongodb://localhost/new-mean'
+process.env.MONGO_PORT= process.env.MONGO_PORT || '27017'
 require('babel-register');
 require("babel-polyfill");
 require('./server');


### PR DESCRIPTION
Don't unconditionally override the values of MONGO_HOST and MONGO_PORT. And, connect the resque service to the net network so that it can reach the mongo service.